### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ sudo apt-get install python3 python3-pip python3-dev gcc default-libmysqlclient-
 sudo yum install python36 python36-pip python36-devel gcc mysql-devel # Red Hat & CentOS
 
 # required Python3 packages
-sudo pip3 install mysqlclient sqlalchemy sqlalchemy-utils
+sudo pip3 install mysqlclient sqlalchemy sqlalchemy-utils pyOpenSSL
 
 # download & install the CLI
 git clone https://github.com/opensips/opensips-cli ~/src/opensips-cli


### PR DESCRIPTION
Install pyOpenSSL to resolve following error:

```bash
# opensips-cli
Traceback (most recent call last):
  File "/sbin/opensips-cli", line 4, in <module>
    __import__('pkg_resources').run_script('opensipscli==0.1.0', 'opensips-cli')
  File "/usr/local/lib/python3.6/site-packages/pkg_resources/__init__.py", line 666, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/usr/local/lib/python3.6/site-packages/pkg_resources/__init__.py", line 1462, in run_script
    exec(code, namespace, namespace)
  File "/usr/local/lib/python3.6/site-packages/opensipscli-0.1.0-py3.6.egg/EGG-INFO/scripts/opensips-cli", line 3, in <module>
    from opensipscli import main
  File "/usr/local/lib/python3.6/site-packages/opensipscli-0.1.0-py3.6.egg/opensipscli/main.py", line 22, in <module>
    from opensipscli import cli, defaults
  File "/usr/local/lib/python3.6/site-packages/opensipscli-0.1.0-py3.6.egg/opensipscli/cli.py", line 31, in <module>
    from opensipscli.modules import *
  File "/usr/local/lib/python3.6/site-packages/opensipscli-0.1.0-py3.6.egg/opensipscli/modules/__init__.py", line 24, in <module>
    __import__(modname)
  File "/usr/local/lib/python3.6/site-packages/opensipscli-0.1.0-py3.6.egg/opensipscli/modules/tls.py", line 3, in <module>
    from OpenSSL import crypto, SSL
ModuleNotFoundError: No module named 'OpenSSL'
```